### PR TITLE
Put everything in one transaction

### DIFF
--- a/lib/swap-selection.coffee
+++ b/lib/swap-selection.coffee
@@ -22,5 +22,6 @@ module.exports = SwapSelection =
       else
         texts.push(texts.shift())
 
-      for selection, i in editor.getSelections()
-        selection.insertText(texts[i], {select: true})
+      editor.transact ->
+        for selection, i in editor.getSelections()
+          selection.insertText(texts[i], {select: true})


### PR DESCRIPTION
It would be more convenient to put all the swaps in _one transaction_ so the user only need _one undo/redo_ every time they swap/cycle.

TextEditor has this method called [transact](https://atom.io/docs/api/v1.7.3/TextEditor#instance-transact) that allows you to put multiple changes in one transaction and it fits the bill in this feature.
